### PR TITLE
Add reshape2 package

### DIFF
--- a/modules/clusterprofiler_ora.nf
+++ b/modules/clusterprofiler_ora.nf
@@ -4,7 +4,7 @@ process CLUSTERPROFILER_ORA {
     conda "conda-forge::r-base=4.1.2 conda-forge::r-conflicted=1.1.0 bioconda::bioconductor-clusterprofiler=4.2.0 " +
         "bioconda::bioconductor-org.hs.eg.db=3.14.0 conda-forge::dplyr=1.0.7 conda-forge::ggplot2=3.3.5 " +
         "conda-forge::r-docopt=0.7.1 bioconda::bioconductor-do.db=2.9=r41hdfd78af_12 conda-forge::r-readr=2.1.1 " +
-        "bioconda::bioconductor-reactomepa=1.38.0 conda-forge::r-ggnewscale=0.4.5"
+        "bioconda::bioconductor-reactomepa=1.38.0 conda-forge::r-ggnewscale=0.4.5 conda-forge::r-reshape2=1.4.4"
 
     input:
     path(de_res)


### PR DESCRIPTION
For some reason building the conda environment on macOS failed when
loading the clusterProfiler package. Probably a version issue of the
reshape2 package that is a dependency of clusterProfiler.